### PR TITLE
Invalid Name causes panic

### DIFF
--- a/nameparts.go
+++ b/nameparts.go
@@ -132,7 +132,14 @@ func Parse(name string) NameParts {
 		if partMap["suffix"] > -1 && partMap["generation"] < lnEnd {
 			lnEnd = partMap["suffix"]
 		}
-		p.slot("last", strings.Join(n.SplitName[partMap["lnprefix"]:lnEnd], " "))
+		// Need to validate the slice parameters make sense
+		// Example Name: "I am the Popsicle"
+		// This example causes a hit on the generation at position 0,
+		// which in turn causes lnEnd to be set to 0, but the lnprefix
+		// is greater than 0, causing a slice out of bounds panic
+		if lnEnd > partMap["lnprefix"] {
+			p.slot("last", strings.Join(n.SplitName[partMap["lnprefix"]:lnEnd], " "))
+		}
 
 		// Keep track of what we've slotted
 		for i := partMap["lnprefix"]; i <= lnEnd; i++ {

--- a/nameparts_test.go
+++ b/nameparts_test.go
@@ -272,6 +272,17 @@ func TestTabsInName(t *testing.T) {
 	}
 }
 
+func TestObviouslyBadName(t *testing.T) {
+	// make sure we don't panic on a clearly bad name
+	defer func() {
+		if r := recover(); r != nil {
+			// panic happened, fail the test
+			t.Errorf("Panic happened, where it shouldn't have")
+		}
+	}()
+	Parse("I am a Popsicle")
+}
+
 func ExampleParse() {
 	res := Parse("Thurston Howell III")
 	fmt.Println("FirstName:", res.FirstName)


### PR DESCRIPTION
slice range out of bounds check performed in the event 'generation' or 'suffix' is in a position before lnprefix

Referencing:
https://github.com/polera/gonameparts/issues/2